### PR TITLE
[WIP] Implement IgnoreErrorFormatter

### DIFF
--- a/src/IgnoreErrorFormatter.php
+++ b/src/IgnoreErrorFormatter.php
@@ -1,0 +1,53 @@
+<?php declare(strict_types = 1);
+
+namespace Grifart\PhpstanOneLine;
+
+use PHPStan\Command\AnalysisResult;
+use PHPStan\Command\ErrorFormatter\ErrorFormatter;
+use PHPStan\File\RelativePathHelper;
+use Symfony\Component\Console\Style\OutputStyle;
+use Symfony\Component\Yaml\Yaml;
+
+class IgnoreErrorFormatter implements ErrorFormatter
+{
+    /** @var RelativePathHelper */
+    private $relativePathHelper;
+
+    public function __construct(RelativePathHelper $relativePathHelper)
+    {
+        $this->relativePathHelper = $relativePathHelper;
+    }
+
+    public function formatErrors(
+        AnalysisResult $analysisResult,
+        OutputStyle $style
+    ): int
+    {
+        if (!$analysisResult->hasErrors()) {
+            return 0;
+        }
+
+        $errors = [];
+
+        foreach ($analysisResult->getFileSpecificErrors() as $fileSpecificError) {
+            $errors[$fileSpecificError->getFile()][] = $fileSpecificError->getMessage();
+        }
+
+        foreach ($errors as $file => $fileErrors) {
+            $fileErrors = array_unique($fileErrors);
+
+            foreach ($fileErrors as $message) {
+                $style->writeln(
+                    sprintf(
+                        "        -\n            message: %s\n            path: %s",
+                        Yaml::dump('%currentWorkingDirectory%/src/' . $this->relativePathHelper->getRelativePath($file)),
+                        Yaml::dump('~' . preg_quote(substr($message, 0, -1), '~') . '~')
+                    )
+                );
+            }
+        }
+
+        return 1;
+    }
+
+}


### PR DESCRIPTION
When dealing with PHPStan in legacy applications it's not always a good idea to go and fix all the errors - higher levels and newer versions of PHPStan can easily report thousands of errors with many false positives and many not-easy-to-fix cases. But you would still like to apply a strict PHPStan to any new code added to the project, right?

The way I'm planning to do it when PHPStan 0.11 comes out is to fix all the errors in my app that are feasible to fix and add some configuration to PHPStan to ignore the rest.

This is where this new ErrorFormatter comes in - it prints all errors in yaml format that you can simply append to your phpstan.neon to ignore the legacy errors. It is using the new [per-file-error-syntax](https://github.com/phpstan/phpstan#ignore-error-messages-with-regular-expressions) from PHPStan 0.11 so we should wait with this until it's released.

PHPStan Pro is the better alternative of course but since it will be a paid service, not everyone can use it. Personally I work on several projects and while I might be able to get PHPStan Pro for some of them, I don't think I can convince my superiors in all cases. So I think it's a good idea to have this free alternative.

What do you think?