### PR TITLE
composer: allow phpstan 0.11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
 	},
     "require": {
         "php": ">= 7.0.0",
-        "phpstan/phpstan": "^0.10.4"
+        "phpstan/phpstan": "^0.10.4|^0.11"
     },
     "license": "MIT",
     "authors": [


### PR DESCRIPTION
At the moment I cannot install this package.

```bash
  Problem 1
    - Installation request for grifart/phpstan-oneline ^0.2.0 -> satisfiable by grifart/phpstan-oneline[v0.2.0].
    - grifart/phpstan-oneline v0.2.0 requires phpstan/phpstan ^0.10.4 -> satisfiable by phpstan/phpstan[0.10.4, 0.10.5, 0.10.6, 0.10.7, 0.10.8, 0.10.x-dev] but these conflict with your requirements or minimum-stability.
```

This should fix it


Ref https://github.com/thecodingmachine/phpstan-safe-rule/pull/7/files