### PR TITLE
Add {absolutePath} variable to CompactErrorFormatter

### DIFF
--- a/src/CompactErrorFormatter.php
+++ b/src/CompactErrorFormatter.php
@@ -43,6 +43,7 @@ class CompactErrorFormatter implements ErrorFormatter
 				strtr(
 					$this->format,
 					[
+						'{absolutePath}' => $fileSpecificError->getFile(),
 						'{path}' => $this->relativePathHelper->getRelativePath($fileSpecificError->getFile()),
 						'{line}' => $fileSpecificError->getLine() ?? '?',
 						'{error}' => $fileSpecificError->getMessage(),


### PR DESCRIPTION
I need the absolute path to the file in my formatter.