### PR TITLE
Use PHPStan's `editorUrl` and add example on how to use Symfony's Console Hyperlinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![License](https://poser.pugx.org/grifart/phpstan-oneline/license)](https://packagist.org/packages/grifart/phpstan-oneline)
 [![Build Status](https://travis-ci.org/grifart/phpstan-oneline.svg?branch=master)](https://travis-ci.org/grifart/phpstan-oneline)
 
-Compact and **clickable** [PhpStan](http://github.com/phpstan/phpstan) error output handler.
+Compact and **clickable** [PHPStan](http://github.com/phpstan/phpstan) error output handler.
 
 So when you run for example:
 
@@ -30,10 +30,27 @@ includes:
 	- vendor/grifart/phpstan-oneline/config.neon
 ```
 
-### Clickable paths in PhpStorm
+### Clickable paths
+
+First, configure PHPStan's [`editorUrl`](https://phpstan.org/config-reference#clickable-editor-url) parameter:
+```neon
+parameters:
+	editorUrl: 'phpstorm://open?file=%%file%%&line=%%line%%'
+```
+
+Then, change the error format to use [Symfony's Console Hyperlinks](https://github.com/symfony/symfony/pull/29168):
+```neon
+parameters:
+	compact:
+		format: "<href={editorUrl}>{path}:{line}</>\n ↳ {error}" # default
+```
+
+The file can now be clicked and opened directly in PHPStorm.
+
+### Clickable paths in PhpStorm's Terminal
 
 1. Install [Awesome Console](https://github.com/anthraxx/intellij-awesome-console) (available in PhpStorm repositories)
-2. run phpstan in PhpStorm terminal
+2. run PHPStan in PhpStorm's terminal
 
 
 ## Custom error format

--- a/config.neon
+++ b/config.neon
@@ -12,8 +12,10 @@ services:
 		class: Grifart\PhpstanOneLine\CompactErrorFormatter
 		arguments:
 			format: %compact.format%
+			editorUrl: %editorUrl%
 
 	errorFormatter.oneline:
 		class: Grifart\PhpstanOneLine\CompactErrorFormatter
 		arguments:
 			format: "{path}:{line} {error}"
+			editorUrl: %editorUrl%

--- a/src/CompactErrorFormatter.php
+++ b/src/CompactErrorFormatter.php
@@ -15,13 +15,18 @@ class CompactErrorFormatter implements ErrorFormatter
 	/** @var string */
 	private $format;
 
+	/** @var string */
+	private $editorUrl;
+
 	public function __construct(
 		RelativePathHelper $relativePathHelper,
-		string $format
+		string $format,
+		?string $editorUrl
 	)
 	{
 		$this->relativePathHelper = $relativePathHelper;
 		$this->format = $format;
+		$this->editorUrl = $editorUrl ?? '';
 	}
 
 	public function formatErrors(
@@ -48,7 +53,8 @@ class CompactErrorFormatter implements ErrorFormatter
 					$this->format,
 					[
 						'{absolutePath}' => $absolutePath,
-						'{path}' => $this->relativePathHelper->getRelativePath($fileSpecificError->getFile()),
+                        '{editorUrl}' => str_replace(['%file%', '%line%'], [$absolutePath, $fileSpecificError->getLine() ?? ''], $this->editorUrl),
+                        '{path}' => $this->relativePathHelper->getRelativePath($fileSpecificError->getFile()),
 						'{line}' => $fileSpecificError->getLine() ?? '?',
 						'{error}' => $fileSpecificError->getMessage(),
 					]


### PR DESCRIPTION
Thanks for this simple but amazing error formatter.

I noticed that clicking the file path in my terminal (iTerm2) would open my default editor (VS Code) instead of my configured [`editorUrl`](https://phpstan.org/config-reference#clickable-editor-url) PHPStorm.

In this PR I added the `editorUrl` so that it's available inside the formatter. The file and line are replaced and then the `editorUrl` variable is available in the formatter.

It uses the same replace format as PHPStan does, see: https://github.com/phpstan/phpstan-src/blob/0f2fbfff2d861e17345981f2c02ab7696a2298e3/src/Command/ErrorFormatter/TableErrorFormatter.php#L86

Together with [Symfony's Console Hyperlinks](https://github.com/symfony/symfony/pull/29168) you can now easily make the paths clickable for almost all terminals.

```neon
parameters:
	editorUrl: 'phpstorm://open?file=%%file%%&line=%%line%%'
	compact:
		format: "<href={editorUrl}>{path}:{line}</>\n ↳ {error}" # default
```

<img width="1054" alt="Screenshot 2021-12-12 at 12 10 27@2x" src="https://user-images.githubusercontent.com/104180/145709968-708ca41f-f766-4ce7-9186-18a4303a2685.png">

